### PR TITLE
[Typo] Remove misplaced semicolon

### DIFF
--- a/src/components/Viewer/MobileViewer/MobileViewer.tsx
+++ b/src/components/Viewer/MobileViewer/MobileViewer.tsx
@@ -106,7 +106,7 @@ export default memo(function MobileViewer({ panel, solid }: Props) {
         )}
       >
         {header}
-        <Panels panel={panel} operationsPanel={OperationsPanel} />;
+        <Panels panel={panel} operationsPanel={OperationsPanel} />
       </div>
       <main className={styles('scene')}>
         <X3dScene label={solid} />


### PR DESCRIPTION
A semicolon is accidentally rendered in HTML - mobile version.

Thanks for maintaining this great repo!